### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,5 +10,7 @@
     "repo": "googleapis/python-monitoring-dashboards",
     "distribution_name": "google-cloud-monitoring-dashboards",
     "api_id": "monitoring.googleapis.com",
-    "requires_billing": true
-  }
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
+}

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-monitoring-dashboards",
     "api_id": "monitoring.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114