### PR TITLE
chore: reference correct client in docs/index.rst

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,20 +2,33 @@
 
 .. include:: multiprocessing.rst
 
-Api Reference
+
+API Reference
 -------------
 .. toctree::
     :maxdepth: 2
 
-    dashboard_v1/services
-    dashboard_v1/types
+    monitoring_dashboard_v1/services
+    monitoring_dashboard_v1/types
+
 
 Migration Guide
 ---------------
 
-See the guide below for instructions on migrating to the 2.x release of this library.
+See the guide below for instructions on migrating to the latest version.
 
 .. toctree::
     :maxdepth: 2
 
-    UPGRADING
+    UPGRADING
+
+
+Changelog
+---------
+
+For a list of all ``google-cloud-monitoring-dashboards`` releases:
+
+.. toctree::
+    :maxdepth: 2
+
+    changelog


### PR DESCRIPTION
`docs/index.rst` should reference https://github.com/googleapis/python-monitoring-dashboards/tree/main/google/cloud/monitoring_dashboard_v1 instead of  https://github.com/googleapis/python-monitoring-dashboards/tree/main/google/monitoring/dashboard_v1